### PR TITLE
skip geojson features with null geometry

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,9 +2,6 @@
   "name": "geojson2osm",
   "version": "0.0.5",
   "main": "./index",
-  "engines": {
-    "node": "4.4.7"
-  },
   "bin": {
     "geojson2osm": "cli.js"
   },

--- a/src/geojson2osm.js
+++ b/src/geojson2osm.js
@@ -200,7 +200,9 @@ geojson2osm.geojson2osm = function(geojson) {
       };
       var obj = [];
       for (var i = 0; i < geojson.features.length; i++) {
-        obj.push(togeojson(geojson.features[i].geometry, geojson.features[i].properties));
+        if (geojson.features[i].geometry) {
+          obj.push(togeojson(geojson.features[i].geometry, geojson.features[i].properties));
+        }
       }
       for (var n = 0; n < obj.length; n++) {
         if (obj[n].nodes !== 'undefined') {


### PR DESCRIPTION
In the 2008 GeoJSON spec "A feature object must have a member with the name "geometry". The value of the geometry member is a geometry object as defined above **or a JSON null value**." http://geojson.org/geojson-spec.html#feature-objects

This PR simply skips those features rather than an error.